### PR TITLE
added change to -s for responding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,11 @@ fn main() {
                 match msg.as_str() {
                     Some(m) => {
                         dbg!(msg.as_str().unwrap());
-                        sub.send(format!("ACK {}", &m[10..]).as_bytes(), 0).unwrap();
+                        if m.contains("heartbeat") {
+                            sub.send(format!("ACK {}", &m[10..]).as_bytes(), 0).unwrap();
+                        } else {
+                            sub.send(format!("ACK {}", &m[8..]).as_bytes(), 0).unwrap();
+                        }
                     }
                     None => {
                         dbg!("recieved None");


### PR DESCRIPTION
closes #2. Honestly that issue was supposed to change the format that it was taking in checkins, but since it is just supposed to be a mirror so we can see when a packet goes through what I did really isn't according to the issue. I made a small change so that when we get a checkin instead of a heartbeat the response is sent correctly.